### PR TITLE
GET/DELETE /v3/record/{id} エンドポイントの実装

### DIFF
--- a/backend/internal/adapter/http/handler.go
+++ b/backend/internal/adapter/http/handler.go
@@ -203,13 +203,40 @@ func (s *Server) GetV3RecordYear(c *gin.Context, year int) {
 // DeleteV3RecordId - delete record from id (DELETE /v3/record/{id})
 func (s *Server) DeleteV3RecordId(c *gin.Context, id int) {
 	// id パラメータは自動的にパースされて渡される
-	c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"})
+	err := s.recordService.DeleteRecord(c.Request.Context(), id)
+	if err != nil {
+		slog.Error("Failed to delete record", slog.Int("id", id), slog.String("error", err.Error()))
+		c.JSON(http.StatusNotFound, gin.H{"error": "record not found"})
+		return
+	}
+
+	// 削除成功時は204 No Contentを返す
+	c.Status(http.StatusNoContent)
 }
 
 // GetV3RecordId - get record from id (GET /v3/record/{id})
 func (s *Server) GetV3RecordId(c *gin.Context, id int) {
 	// id パラメータは自動的にパースされて渡される
-	c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"})
+	record, err := s.recordService.GetRecordByID(c.Request.Context(), id)
+	if err != nil {
+		slog.Error("Failed to get record", slog.Int("id", id), slog.String("error", err.Error()))
+		c.JSON(http.StatusNotFound, gin.H{"error": "record not found"})
+		return
+	}
+
+	// APIレスポンス型に変換
+	response := api.Record{
+		Id:           record.ID,
+		CategoryId:   record.CategoryID,
+		CategoryName: record.CategoryName,
+		Datetime:     record.Datetime,
+		From:         record.From,
+		Type:         record.Type,
+		Price:        record.Price,
+		Memo:         record.Memo,
+	}
+
+	c.JSON(http.StatusOK, response)
 }
 
 // GetV3Version - get version (GET /v3/version)

--- a/backend/internal/adapter/http/handler_test.go
+++ b/backend/internal/adapter/http/handler_test.go
@@ -29,8 +29,10 @@ func (m *mockCategoryRepository) FindAll(ctx context.Context) ([]*domain.Categor
 
 // mockRecordRepository はテスト用のモックリポジトリ
 type mockRecordRepository struct {
-	records []*domain.Record
-	err     error
+	records      []*domain.Record
+	err          error
+	findByIDFunc func(ctx context.Context, id int) (*domain.Record, error)
+	deleteFunc   func(ctx context.Context, id int) error
 }
 
 func (m *mockRecordRepository) Create(ctx context.Context, record *domain.Record) (*domain.Record, error) {
@@ -38,6 +40,9 @@ func (m *mockRecordRepository) Create(ctx context.Context, record *domain.Record
 }
 
 func (m *mockRecordRepository) FindByID(ctx context.Context, id int) (*domain.Record, error) {
+	if m.findByIDFunc != nil {
+		return m.findByIDFunc(ctx, id)
+	}
 	return nil, nil
 }
 
@@ -50,6 +55,9 @@ func (m *mockRecordRepository) Count(ctx context.Context, yyyymm string, categor
 }
 
 func (m *mockRecordRepository) Delete(ctx context.Context, id int) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, id)
+	}
 	return nil
 }
 
@@ -131,6 +139,133 @@ func TestGetV3Categories(t *testing.T) {
 				if tt.checkResponseFunc != nil {
 					tt.checkResponseFunc(t, response)
 				}
+			}
+		})
+	}
+}
+
+func TestGetV3RecordId(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name              string
+		recordID          int
+		mockRepo          *mockRecordRepository
+		wantStatusCode    int
+		checkResponseFunc func(t *testing.T, response api.Record)
+	}{
+		{
+			name:     "正常系: IDでレコードを取得できる",
+			recordID: 1,
+			mockRepo: &mockRecordRepository{
+				findByIDFunc: func(ctx context.Context, id int) (*domain.Record, error) {
+					return &domain.Record{
+						ID:           1,
+						CategoryID:   100,
+						CategoryName: "月給",
+						Price:        300000,
+						From:         "会社A",
+						Type:         "salary",
+						Memo:         "テストメモ",
+					}, nil
+				},
+			},
+			wantStatusCode: http.StatusOK,
+			checkResponseFunc: func(t *testing.T, response api.Record) {
+				if response.Id != 1 {
+					t.Errorf("expected id 1, got %d", response.Id)
+				}
+				if response.CategoryId != 100 {
+					t.Errorf("expected category_id 100, got %d", response.CategoryId)
+				}
+				if response.Price != 300000 {
+					t.Errorf("expected price 300000, got %d", response.Price)
+				}
+			},
+		},
+		{
+			name:     "異常系: レコードが見つからない",
+			recordID: 999,
+			mockRepo: &mockRecordRepository{
+				findByIDFunc: func(ctx context.Context, id int) (*domain.Record, error) {
+					return nil, context.DeadlineExceeded
+				},
+			},
+			wantStatusCode:    http.StatusNotFound,
+			checkResponseFunc: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			categoryService := application.NewCategoryService(&mockCategoryRepository{})
+			recordService := application.NewRecordService(tt.mockRepo)
+			dbInfo := &config.DBInfo{}
+			server := NewServer("localhost", 8080, "v1.0.0", "abc123", "20250101", dbInfo, categoryService, recordService)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/api/v3/record/1", nil)
+			server.router.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatusCode {
+				t.Errorf("expected status code %d, got %d", tt.wantStatusCode, w.Code)
+			}
+
+			if tt.wantStatusCode == http.StatusOK && tt.checkResponseFunc != nil {
+				var response api.Record
+				if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				tt.checkResponseFunc(t, response)
+			}
+		})
+	}
+}
+
+func TestDeleteV3RecordId(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		recordID       int
+		mockRepo       *mockRecordRepository
+		wantStatusCode int
+	}{
+		{
+			name:     "正常系: IDでレコードを削除できる",
+			recordID: 1,
+			mockRepo: &mockRecordRepository{
+				deleteFunc: func(ctx context.Context, id int) error {
+					return nil
+				},
+			},
+			wantStatusCode: http.StatusNoContent,
+		},
+		{
+			name:     "異常系: レコードが見つからない",
+			recordID: 999,
+			mockRepo: &mockRecordRepository{
+				deleteFunc: func(ctx context.Context, id int) error {
+					return context.DeadlineExceeded
+				},
+			},
+			wantStatusCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			categoryService := application.NewCategoryService(&mockCategoryRepository{})
+			recordService := application.NewRecordService(tt.mockRepo)
+			dbInfo := &config.DBInfo{}
+			server := NewServer("localhost", 8080, "v1.0.0", "abc123", "20250101", dbInfo, categoryService, recordService)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("DELETE", "/api/v3/record/1", nil)
+			server.router.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatusCode {
+				t.Errorf("expected status code %d, got %d", tt.wantStatusCode, w.Code)
 			}
 		})
 	}


### PR DESCRIPTION
## 概要
GET /v3/record/{id} と DELETE /v3/record/{id} エンドポイントを実装しました。

## 変更内容
- GET /v3/record/{id} エンドポイントの実装
  - 指定されたIDのレコードを取得
  - レコードが見つからない場合は404を返す
- DELETE /v3/record/{id} エンドポイントの実装
  - 指定されたIDのレコードを削除
  - 削除成功時は204 No Contentを返す
  - レコードが見つからない場合は404を返す
- テーブルドリブン形式のテストケース追加
  - TestGetV3RecordId: 正常系と異常系
  - TestDeleteV3RecordId: 正常系と異常系

## テスト結果

### ユニットテスト
全てのテストが成功しています。

### E2Eテスト実施結果

#### テスト環境
- API サーバー: localhost:8080
- データベース: MariaDB (mawinter データベース)
- テストツール: curl

#### 実施したテスト項目

**1. GET /v3/record/{id} エンドポイント**

正常系:
- ✓ 既存レコード（ID: 1, 2）の取得が成功
- ✓ レスポンスに必要な全フィールドが含まれることを確認
  - id, category_id, category_name, datetime, from, type, price, memo

異常系/エッジケース:
- ✓ 存在しないID (999) → HTTP 404 + `{"error":"record not found"}`
- ✓ 無効なID形式 (abc) → HTTP 400 + パラメータエラーメッセージ
- ✓ ID 0 → HTTP 404
- ✓ 負のID (-1) → HTTP 404

**2. DELETE /v3/record/{id} エンドポイント**

正常系:
- ✓ 既存レコードの削除が成功 (HTTP 204 No Content)
- ✓ 削除後、GETリクエストで HTTP 404 が返ることを確認

異常系/エッジケース:
- ✓ 存在しないID (999) → HTTP 404 + `{"error":"record not found"}`
- ✓ 無効なID形式 (abc) → HTTP 400 + パラメータエラーメッセージ
- ✓ すでに削除されたレコードの削除 → HTTP 404

**3. 既存エンドポイントとの整合性テスト**
- ✓ DELETE後、GET /v3/record でレコード一覧が正しく更新される
- ✓ DELETE後、GET /v3/record/count でカウントが正しく減少する
- ✓ 全レコード削除後、空配列 `[]` とカウント `{"num":0}` が返される

**4. 完全なワークフローテスト**
- ✓ POST /v3/record → GET /v3/record/{id} → DELETE /v3/record/{id} → GET /v3/record/{id} の一連の流れが正常に動作

#### E2Eテスト結果サマリ

すべてのテストケースが成功しました。実装されたエンドポイントは以下の点で正しく動作しています:

1. 正常系のリクエストに対して適切なレスポンスを返す
2. 異常系のリクエストに対して適切なHTTPステータスコードとエラーメッセージを返す
3. 既存のエンドポイント（POST /v3/record、GET /v3/record、GET /v3/record/count）との整合性が保たれている
4. レコードの作成、取得、削除の完全なライフサイクルが正常に機能する

Generated with [Claude Code](https://claude.com/claude-code)