### PR TITLE
GET /v3/record/available エンドポイントの実装

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/azuki774/mawinter
 go 1.25.3
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/gin-gonic/gin v1.11.0
 	github.com/oapi-codegen/runtime v1.1.2
@@ -13,7 +14,6 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.14.1 // indirect

--- a/backend/internal/adapter/http/handler.go
+++ b/backend/internal/adapter/http/handler.go
@@ -162,7 +162,21 @@ func (s *Server) PostV3Record(c *gin.Context) {
 
 // GetV3RecordAvailable - record available (GET /v3/record/available)
 func (s *Server) GetV3RecordAvailable(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"})
+	// レコードの利用可能期間を取得
+	yyyymm, fy, err := s.recordService.GetAvailablePeriods(c.Request.Context())
+	if err != nil {
+		slog.Error("Failed to get available periods", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get available periods"})
+		return
+	}
+
+	// APIレスポンス型に変換
+	response := gin.H{
+		"fy":     fy,
+		"yyyymm": yyyymm,
+	}
+
+	c.JSON(http.StatusOK, response)
 }
 
 // GetV3RecordCount - record count (GET /v3/record/count)

--- a/backend/internal/adapter/http/handler_test.go
+++ b/backend/internal/adapter/http/handler_test.go
@@ -61,6 +61,10 @@ func (m *mockRecordRepository) Delete(ctx context.Context, id int) error {
 	return nil
 }
 
+func (m *mockRecordRepository) GetAvailablePeriods(ctx context.Context) ([]string, []string, error) {
+	return nil, nil, nil
+}
+
 func TestGetV3Categories(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/application/record_service.go
+++ b/backend/internal/application/record_service.go
@@ -42,3 +42,8 @@ func (s *RecordService) CountRecords(ctx context.Context, yyyymm string, categor
 func (s *RecordService) DeleteRecord(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
 }
+
+// GetAvailablePeriods はDBに登録されているレコードのYYYYMMとFY(年度)の一覧を取得する
+func (s *RecordService) GetAvailablePeriods(ctx context.Context) ([]string, []string, error) {
+	return s.repo.GetAvailablePeriods(ctx)
+}

--- a/backend/internal/domain/record_repository.go
+++ b/backend/internal/domain/record_repository.go
@@ -23,4 +23,8 @@ type RecordRepository interface {
 
 	// Delete は指定されたIDのレコードを削除する
 	Delete(ctx context.Context, id int) error
+
+	// GetAvailablePeriods はDBに登録されているレコードのYYYYMMとFY(年度)の一覧を取得する
+	// 返される配列はいずれも新しい順にソートされている
+	GetAvailablePeriods(ctx context.Context) (yyyymm []string, fy []string, err error)
 }


### PR DESCRIPTION
## 概要
`GET /v3/record/available` エンドポイントを実装しました。このエンドポイントは、DBに登録されているレコードの年月(YYYYMM)と年度(FY)の一覧を返します。

## 実装内容

### 機能
- Recordテーブルのdatetimeカラムから、利用可能な年月(YYYYMM)と年度(FY)を抽出
- 年度は4月始まり(4月〜翌年3月)で計算
  - 例: 2024年4月 → FY2024
  - 例: 2024年3月 → FY2023
- レスポンスは新しい順にソート済み
- **SQLベースの最適化**: データベース側で集約処理を実行し、パフォーマンスとメモリ効率を改善

### 変更ファイル
- `internal/domain/record_repository.go`: リポジトリインターフェースにGetAvailablePeriodsメソッドを追加
- `internal/adapter/repository/record_repository.go`: SQLベースの効率的な実装
- `internal/adapter/repository/record_repository_test.go`: リポジトリ層のユニットテスト追加
- `internal/application/record_service.go`: アプリケーション層にGetAvailablePeriodsを追加
- `internal/adapter/http/handler.go`: HTTPハンドラの実装
- `internal/adapter/http/handler_test.go`: モックリポジトリにメソッド追加
- `go.mod`: go-sqlmockを直接依存として追加

### パフォーマンス最適化
全レコードをメモリに読み込む代わりに、SQLの`DISTINCT`と集約関数を使用:

**YYYYMM取得**
```sql
SELECT DISTINCT DATE_FORMAT(datetime, '%Y%m') as yyyymm 
FROM Record 
ORDER BY yyyymm DESC
```

**FY(年度)取得**
```sql
SELECT DISTINCT 
  CASE WHEN MONTH(datetime) BETWEEN 1 AND 3 
    THEN YEAR(datetime) - 1 
    ELSE YEAR(datetime) 
  END as fy 
FROM Record 
ORDER BY fy DESC
```

## テスト結果

### ユニットテスト
全てのテストがパスしました。

```
=== RUN   TestRecordRepository_GetAvailablePeriods
=== RUN   TestRecordRepository_GetAvailablePeriods/正常系:_複数年月のレコードから期間を取得
=== RUN   TestRecordRepository_GetAvailablePeriods/正常系:_同じ年月の重複レコードは1つにまとめる
=== RUN   TestRecordRepository_GetAvailablePeriods/正常系:_レコードが0件の場合は空配列を返す
=== RUN   TestRecordRepository_GetAvailablePeriods/正常系:_年度境界のテスト（3月と4月）
--- PASS: TestRecordRepository_GetAvailablePeriods
```

### E2Eテスト結果

#### テストデータ
以下のテストデータを使用:

| 日付 | 年 | 月 | FY | YYYYMM | メモ |
|------|----|----|-------|--------|------|
| 2025-02-01 | 2025 | 2 | 2024 | 202502 | FY2024年2月のテスト |
| 2024-05-15 | 2024 | 5 | 2024 | 202405 | FY2024年5月のテスト |
| 2024-04-01 | 2024 | 4 | 2024 | 202404 | FY2024年4月のテスト |
| 2024-03-31 | 2024 | 3 | 2023 | 202403 | FY2023年3月のテスト |
| 2023-12-25 | 2023 | 12 | 2023 | 202312 | FY2023年12月のテスト |
| 2023-05-10 | 2023 | 5 | 2023 | 202305 | FY2023年5月のテスト |

#### APIレスポンス
**リクエスト**: `GET /v3/record/available`

**レスポンス** (HTTP 200):
```json
{
  "fy": ["2024", "2023"],
  "yyyymm": ["202502", "202405", "202404", "202403", "202312", "202305"]
}
```

#### 検証項目
- ✅ 年月が新しい順にソートされている
- ✅ 年度が新しい順にソートされている
- ✅ 年度の計算が正しい(4月始まり)
  - 2025年2月 → FY2024 (1-3月は前年度)
  - 2024年4月 → FY2024 (4月は当年度の開始月)
  - 2024年3月 → FY2023 (3月は前年度の終了月)
- ✅ レコードが0件の場合、空配列を返す: `{"fy":[],"yyyymm":[]}`
- ✅ 重複が正しく排除されている

全ての検証項目をクリアしました。

Generated with [Claude Code](https://claude.com/claude-code)