### PR TITLE
[codex] Fix OpenTelemetry schema URL conflict on startup

### DIFF
--- a/backend/pkg/telemetry/telemetry.go
+++ b/backend/pkg/telemetry/telemetry.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 // Mawinter 内で使用するサービス名の定数
@@ -38,8 +38,7 @@ func Init(ctx context.Context, endpoint, serviceName, version string) (ShutdownF
 
 	res, err := resource.Merge(
 		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
+		resource.NewSchemaless(
 			semconv.ServiceName(serviceName),
 			semconv.ServiceVersion(version),
 		),

--- a/backend/pkg/telemetry/telemetry_test.go
+++ b/backend/pkg/telemetry/telemetry_test.go
@@ -1,0 +1,52 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInit(t *testing.T) {
+	tests := []struct {
+		name        string
+		endpoint    string
+		wantEnabled bool
+		wantErr     bool
+	}{
+		{
+			name:        "正常系: endpoint未指定ならトレーシングを無効化する",
+			endpoint:    "",
+			wantEnabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "正常系: endpoint指定時にトレーシングを初期化できる",
+			endpoint:    "http://localhost:4318",
+			wantEnabled: true,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shutdown, enabled, err := Init(context.Background(), tt.endpoint, ServiceNameAPI, "dev")
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if enabled != tt.wantEnabled {
+				t.Errorf("Init() enabled = %v, want %v", enabled, tt.wantEnabled)
+			}
+
+			if err == nil {
+				if shutdown == nil {
+					t.Fatal("Init() shutdown is nil")
+				}
+				if err := shutdown(context.Background()); err != nil {
+					t.Errorf("shutdown() error = %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
- OpenTelemetry 初期化時の Schema URL 衝突を解消しました
- 起動時デグレを防ぐ回帰テストを追加しました

## 原因
PR #39 で OpenTelemetry 本体が更新された一方、`backend/pkg/telemetry/telemetry.go` では古い `semconv` を参照したままでした。
その状態で `resource.Default()` と `resource.NewWithAttributes()` をマージすると、異なる Schema URL が混在して `failed to build resource: conflicting Schema URL` で起動に失敗していました。

## 変更内容
- `semconv` の参照を OpenTelemetry SDK 側に合わせて更新
- service 属性の付与を `resource.NewSchemaless(...)` に変更し、Schema URL の衝突を回避
- `telemetry.Init` の回帰テストを追加

## 影響
- `OTLP_SERVER` を設定していても `mawinter serve` が起動できるようになります
- トレーシング有効時の起動失敗デグレを防止します

## 確認
- ローカルではこのホストに `go` 実行環境が見えず `go test` / `make test` は未実行
- GitHub Actions の CI で `go test` を確認予定